### PR TITLE
Typo in Wikipedia blog post assignment

### DIFF
--- a/_includes/daily/14.markdown
+++ b/_includes/daily/14.markdown
@@ -50,7 +50,7 @@ what did you learn, what are the tasks that you will be working on next week
     - do you think you might one day become a regular contributor
     - how will you select the articles to contribute as part of the required
       contributions for this class?
-    - watch and comment of the TED talk that Jimmy Wales gave on the [_Birth of Wikipedia_](https://www.youtube.com/watch?v=rAgpogTplzo) in 2005 (did you find any ideas and topics that were out of date?)
+    - watch and comment on the TED talk that Jimmy Wales gave on the [_Birth of Wikipedia_](https://www.youtube.com/watch?v=rAgpogTplzo) in 2005 (did you find any ideas and topics that were out of date?)
 - update the contributions page on your blog (do not include your team contributions there, but
 make sure that all of your own contributions are there)
 


### PR DESCRIPTION
Instead of "watch and comment **of** the TED talk ..." it should say "watch and comment **on** the TED talk ..."