### PR TITLE
feat: add a function to throttle scrolling events

### DIFF
--- a/slides/js/remark.js
+++ b/slides/js/remark.js
@@ -1751,13 +1751,13 @@ module.exports = Keyboard;
 
 function Keyboard(events) {
   this._events = events;
-  
+
   this.activate();
 }
 
 Keyboard.prototype.activate = function () {
   this._gotoSlideNumber = '';
-  
+
   this.addKeyboardEventListeners();
 };
 
@@ -1768,7 +1768,7 @@ Keyboard.prototype.deactivate = function () {
 Keyboard.prototype.addKeyboardEventListeners = function () {
   var self = this;
   var events = this._events;
-  
+
   events.on('keydown', function (event) {
     if (event.metaKey || event.ctrlKey) {
       // Bail out if meta or ctrl key was pressed
@@ -1816,7 +1816,7 @@ Keyboard.prototype.addKeyboardEventListeners = function () {
       // Bail out if meta or ctrl key was pressed
       return;
     }
-    
+
     var key = String.fromCharCode(event.which).toLowerCase();
 
     switch (key) {
@@ -1844,15 +1844,15 @@ Keyboard.prototype.addKeyboardEventListeners = function () {
       case 't':
         events.emit('resetTimer');
         break;
-      case '1': 
-      case '2': 
-      case '3': 
-      case '4': 
+      case '1':
+      case '2':
+      case '3':
+      case '4':
       case '5':
-      case '6': 
-      case '7': 
-      case '8': 
-      case '9': 
+      case '6':
+      case '7':
+      case '8':
+      case '9':
       case '0':
         self._gotoSlideNumber += key;
         break;
@@ -1866,7 +1866,7 @@ Keyboard.prototype.addKeyboardEventListeners = function () {
 
 Keyboard.prototype.removeKeyboardEventListeners = function () {
   var events = this._events;
-  
+
   events.removeAllListeners("keydown");
   events.removeAllListeners("keypress");
 };
@@ -1938,6 +1938,17 @@ exports.unregister = function (events) {
   removeMouseEventListeners(events);
 };
 
+function throttle(events, eventName) {
+  var timestamp = null;
+  return function() {
+    var now = Date.now();
+    if (timestamp === null || now - timestamp > 100) {
+      events.emit(eventName);
+    }
+    timestamp = now;
+  }
+}
+
 function addMouseEventListeners (events, options) {
   if (options.click) {
     events.on('click', function (event) {
@@ -1958,14 +1969,17 @@ function addMouseEventListeners (events, options) {
       events.emit('gotoPreviousSlide');
     });
   }
-
+  var throttledPrev = throttle(events, 'gotoPreviousSlide');
+  var throttledNext = throttle(events, 'gotoNextSlide');
   if (options.scroll !== false) {
     var scrollHandler = function (event) {
       if (event.wheelDeltaY > 0 || event.detail < 0) {
-        events.emit('gotoPreviousSlide');
+        // events.emit('gotoPreviousSlide');
+        throttledPrev();
       }
       else if (event.wheelDeltaY < 0 || event.detail > 0) {
-        events.emit('gotoNextSlide');
+        // events.emit('gotoNextSlide');
+        throttledNext();
       }
     };
 
@@ -6072,7 +6086,7 @@ function(hljs) {
 }
 },{name:"csp",create:/*
 Language: CSP
-Description: Content Security Policy definition highlighting 
+Description: Content Security Policy definition highlighting
 Author: Taras <oxdef@oxdef.info>
 
 vim: ts=2 sw=2 st=2
@@ -6085,7 +6099,7 @@ function(hljs) {
     keywords: {
       keyword: 'base-uri child-src connect-src default-src font-src form-action' +
         ' frame-ancestors frame-src img-src media-src object-src plugin-types' +
-        ' report-uri sandbox script-src style-src', 
+        ' report-uri sandbox script-src style-src',
     },
     contains: [
     {
@@ -7590,7 +7604,7 @@ function(hljs) {
     },
     contains: [
       {
-        /* matches a beginning equal sign found in Excel formula examples */ 
+        /* matches a beginning equal sign found in Excel formula examples */
         begin: /^=/,
         end: /[^=]/, returnEnd: true, illegal: /=/, /* only allow single equal sign at front of line */
         relevance: 10
@@ -13475,7 +13489,7 @@ function(hljs) {
   var PS_HELPTAGS = {
     className: 'doctag',
     variants: [
-      /* no paramater help tags */ 
+      /* no paramater help tags */
       { begin: /\.(synopsis|description|example|inputs|outputs|notes|link|component|role|functionality)/ },
       /* one parameter help tags */
       { begin: /\.(parameter|forwardhelptargetname|forwardhelpcategory|remotehelprunspace|externalhelp)\s+\S+/ }
@@ -19780,11 +19794,11 @@ SlideView.prototype.scaleBackgroundImage = function (dimensions) {
 function createSlideElement(slide) {
   var element = document.createElement('div');
   element.className = 'remark-slide';
-  
+
   if (slide.properties.continued === 'true') {
     utils.addClass(element, 'remark-slide-incremental');
   }
-  
+
   return element;
 }
 


### PR DESCRIPTION
Currently, when a user scroll in slides, `gotoNextSlide` and `gotoPreviousSlide` will be triggered multiple times. Even if you slightly scroll on your touch pad, you will go to the first or the last slide. I add a function to create two throttled events emitter.

The `throttle` function locates at line 1941 - 1950.

Now instead of trigger `events.emit('gotoPreviousSlide')`, it triggers the throttled function. Therefore, scrolling will move the slides by 1.
